### PR TITLE
Fix password auth for `with_scope` calls

### DIFF
--- a/aioetcd3/lease.py
+++ b/aioetcd3/lease.py
@@ -87,8 +87,13 @@ class Lease(StubMixin):
             for re in [request]:
                 yield re
 
+        await self._authenticate_if_needed()
         new_lease = None
-        async with self._lease_stub.LeaseKeepAlive.with_scope(generate_request(lease_request)) as result:
+        async with self._lease_stub.LeaseKeepAlive.with_scope(
+            generate_request(lease_request),
+            credentials=self._call_credentials,
+            metadata=self._metadata
+        ) as result:
             async for r in result:
                 self._update_cluster_info(r.header)
                 new_lease = RLease(r.TTL, r.ID, self)

--- a/aioetcd3/watch.py
+++ b/aioetcd3/watch.py
@@ -205,8 +205,12 @@ class Watch(StubMixin):
                 if n is None:
                     break
                 yield n
+
         async def watch_call(input_queue, watch_stub, output_pipe):
-            async with watch_stub.Watch.with_scope(input_iterator(input_queue)) as response_iter:
+            await self._authenticate_if_needed()
+            async with watch_stub.Watch.with_scope(
+                    input_iterator(input_queue), credentials=self._call_credentials, metadata=self._metadata
+            ) as response_iter:
                 async for r in response_iter:
                     await output_pipe.put(r)
         last_received_revision = None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.12"
+version = "1.13"
 
 try:
     import pypandoc

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,17 @@
+async def switch_auth_on(client):
+    await client.user_add(username="root", password="root")
+    await client.role_add(name="root")
+    await client.user_grant_role(username="root", role="root")
+
+    await client.user_add(username="client", password="client")
+    await client.role_add(name="client")
+    await client.user_grant_role(username="client", role="client")
+    await client.auth_enable()
+
+
+async def switch_auth_off(root_client, unautheticated_client):
+    await root_client.auth_disable()
+    await unautheticated_client.user_delete("client")
+    await unautheticated_client.user_delete("root")
+    await unautheticated_client.role_delete("client")
+    await unautheticated_client.role_delete("root")


### PR DESCRIPTION
In the previous pull request, I missed the authentication for `with_scope` calls. Now it is fixed and tested